### PR TITLE
Set timeout for Drone initialization

### DIFF
--- a/junit/src/main/resources/arquillian.xml
+++ b/junit/src/main/resources/arquillian.xml
@@ -21,6 +21,7 @@
 
     <extension qualifier="webdriver">
         <property name="browser">firefox</property>
+        <property name="marionette-port">0</property>
     </extension>
 
     <extension qualifier="graphene">
@@ -28,5 +29,9 @@
         <property name="waitGuiInterval">10</property>
         <property name="waitAjaxInterval">20</property>
         <property name="waitModelInterval">30</property>
+    </extension>
+
+    <extension qualifier="drone">
+        <property name="instantiationTimeoutInSeconds">120</property>
     </extension>
 </arquillian>


### PR DESCRIPTION
Eliminate intermittent test failures caused by Drone's inability to establish a connection to WebDriver.







