### PR TITLE
HAL-2056 Use valid class for custom infinispan cache store tests

### DIFF
--- a/fixture/src/main/java/org/jboss/hal/testsuite/fixtures/InfinispanFixtures.java
+++ b/fixture/src/main/java/org/jboss/hal/testsuite/fixtures/InfinispanFixtures.java
@@ -41,6 +41,7 @@ public final class InfinispanFixtures {
     public static final String LOCAL_CACHE_ITEM = "local-cache-item";
     public static final String MAX_BATCH_SIZE = "max-batch-size";
     public static final String MAX_IDLE = "max-idle";
+    public static final String CUSTOM_STORE_CLASS = "org.infinispan.configuration.cache.CustomStoreConfigurationBuilder";
     public static final String WRITE = "write";
     public static final String BEHIND = "behind";
     public static final String THROUGH = "through";

--- a/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/AttributesTest.java
+++ b/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/AttributesTest.java
@@ -35,6 +35,7 @@ import org.wildfly.extras.creaper.core.online.operations.Values;
 
 import static org.jboss.hal.testsuite.container.WildFlyConfiguration.FULL_HA;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CC_CREATE;
+import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CUSTOM_STORE_CLASS;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.SC_CREATE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.customStoreAddress;
 
@@ -47,7 +48,7 @@ class AttributesTest {
     @BeforeAll
     static void setupModel() throws Exception {
         StoreSetup.setup(wildFly, operations -> operations.headers(Values.of("allow-resource-service-restart", true))
-                .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of("class", Random.name())).assertSuccess());
+                .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of("class", CUSTOM_STORE_CLASS)).assertSuccess());
     }
 
     @Inject Console console;

--- a/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/BehindTest.java
+++ b/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/BehindTest.java
@@ -15,7 +15,6 @@
  */
 package org.jboss.hal.testsuite.test.configuration.infinispan.cache.container.scattered.cache.store.custom;
 
-import org.jboss.hal.testsuite.Random;
 import org.jboss.hal.testsuite.container.WildFlyContainer;
 import org.jboss.hal.testsuite.fragment.FormFragment;
 import org.jboss.hal.testsuite.page.configuration.ScatteredCachePage;
@@ -33,6 +32,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
 import static org.jboss.hal.testsuite.container.WildFlyConfiguration.FULL_HA;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.BEHIND;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CC_CREATE;
+import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CUSTOM_STORE_CLASS;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.SC_CREATE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.WRITE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.customStoreAddress;
@@ -47,7 +47,7 @@ class BehindTest extends AbstractBehindTest {
     static void setupModel() throws Exception {
         StoreSetup.setup(wildFly, operations -> {
             operations.headers(Values.of(ALLOW_RESOURCE_SERVICE_RESTART, true))
-                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, Random.name())).assertSuccess();
+                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, CUSTOM_STORE_CLASS)).assertSuccess();
             operations.add(customStoreAddress(CC_CREATE, SC_CREATE).and(WRITE, BEHIND)).assertSuccess();
         });
     }

--- a/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/BehindToThroughTest.java
+++ b/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/BehindToThroughTest.java
@@ -15,7 +15,6 @@
  */
 package org.jboss.hal.testsuite.test.configuration.infinispan.cache.container.scattered.cache.store.custom;
 
-import org.jboss.hal.testsuite.Random;
 import org.jboss.hal.testsuite.container.WildFlyContainer;
 import org.jboss.hal.testsuite.page.configuration.ScatteredCachePage;
 import org.jboss.hal.testsuite.test.Manatoko;
@@ -32,6 +31,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE
 import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
 import static org.jboss.hal.testsuite.container.WildFlyConfiguration.FULL_HA;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CC_CREATE;
+import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CUSTOM_STORE_CLASS;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.SC_CREATE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.THROUGH;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.WRITE;
@@ -47,7 +47,7 @@ class BehindToThroughTest extends AbstractBehindToThroughTest {
     static void setupModel() throws Exception {
         StoreSetup.setup(wildFly, operations -> {
             operations.headers(Values.of(ALLOW_RESOURCE_SERVICE_RESTART, true))
-                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, Random.name())).assertSuccess();
+                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, CUSTOM_STORE_CLASS)).assertSuccess();
             operations.add(customStoreAddress(CC_CREATE, SC_CREATE).and(WRITE, THROUGH)).assertSuccess();
         });
     }

--- a/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/ThroughToBehindTest.java
+++ b/test-configuration-infinispan/src/test/java/org/jboss/hal/testsuite/test/configuration/infinispan/cache/container/scattered/cache/store/custom/ThroughToBehindTest.java
@@ -15,7 +15,6 @@
  */
 package org.jboss.hal.testsuite.test.configuration.infinispan.cache.container.scattered.cache.store.custom;
 
-import org.jboss.hal.testsuite.Random;
 import org.jboss.hal.testsuite.container.WildFlyContainer;
 import org.jboss.hal.testsuite.page.configuration.ScatteredCachePage;
 import org.jboss.hal.testsuite.test.Manatoko;
@@ -33,6 +32,7 @@ import static org.jboss.hal.dmr.ModelDescriptionConstants.CLASS;
 import static org.jboss.hal.testsuite.container.WildFlyConfiguration.FULL_HA;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.BEHIND;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CC_CREATE;
+import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.CUSTOM_STORE_CLASS;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.SC_CREATE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.WRITE;
 import static org.jboss.hal.testsuite.fixtures.InfinispanFixtures.customStoreAddress;
@@ -47,7 +47,7 @@ class ThroughToBehindTest extends AbstractThroughToBehindTest {
     static void setupModel() throws Exception {
         StoreSetup.setup(wildFly, operations -> {
             operations.headers(Values.of(ALLOW_RESOURCE_SERVICE_RESTART, true))
-                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, Random.name())).assertSuccess();
+                    .add(customStoreAddress(CC_CREATE, SC_CREATE), Values.of(CLASS, CUSTOM_STORE_CLASS)).assertSuccess();
             operations.add(customStoreAddress(CC_CREATE, SC_CREATE).and(WRITE, BEHIND)).assertSuccess();
         });
     }


### PR DESCRIPTION
## Summary

- Replace `Random.name()` with `org.infinispan.configuration.cache.CustomStoreConfigurationBuilder` as the `class` attribute for custom infinispan cache store test setup
- Add `CUSTOM_STORE_CLASS` constant in `InfinispanFixtures`
- The previous random string caused `ClassNotFoundException` at runtime because WildFly's `CustomStoreResourceDefinitionRegistrar` loads the class via `ClassLoader.loadClass()` and casts it to `StoreConfigurationBuilder`

Fixes [HAL-2056](https://redhat.atlassian.net/browse/HAL-2056)